### PR TITLE
解析HTMl前台

### DIFF
--- a/workHomeWebApp/src/app/pages/teacher/work/edit/edit.component.html
+++ b/workHomeWebApp/src/app/pages/teacher/work/edit/edit.component.html
@@ -20,8 +20,8 @@
     <div class="col-md-2 form-text text-right">
       <label>作答：</label>
     </div>
-
-    <textarea> {{work?.content}}</textarea>
+    <div class="col-md-8" [innerHTML]=work?.content>
+    </div>
 
   </div>
   <div class="row mt-5">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40569701/78096027-24dac200-740b-11ea-827f-407011f26bf4.png)

编辑器的样式也可以显示过来（比如编辑器设置了字体加粗，在渲染时也会是加粗的字体），具体怎么实现
@zhangwenda4917 
去查一下